### PR TITLE
fix: pyyaml removed from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.6"
 
-PyYAML = "^5.1"
-
 [tool.poetry.dev-dependencies]
 # codestyle
 catalyst-codestyle = "21.07rc0"


### PR DESCRIPTION
Hydra-slayer meant to be used to process parameters,
not to read them from a file. So remove YAML and JSON from dependencies.