### PR TITLE
fix: `collections.MutableMapping` DeprecationWarning

### DIFF
--- a/hydra_slayer/registry.py
+++ b/hydra_slayer/registry.py
@@ -1,5 +1,5 @@
 from typing import Any, Callable, Dict, Iterator, List, Mapping, Optional, Tuple, Union
-import collections
+from collections import abc
 import copy
 import inspect
 import pydoc
@@ -14,7 +14,7 @@ LateAddCallback = Callable[["Registry"], None]
 MetaFactory = Callable[[Factory, Tuple, Mapping], Any]
 
 
-class Registry(collections.MutableMapping):
+class Registry(abc.MutableMapping):
     """
     Universal class allowing to add and access various factories by name.
 


### PR DESCRIPTION
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
```