### PR TITLE
refactor: `metafactory_factory` added

### DIFF
--- a/hydra_slayer/__init__.py
+++ b/hydra_slayer/__init__.py
@@ -1,4 +1,9 @@
 # flake8: noqa
-from hydra_slayer.factory import call_meta_factory, partial_meta_factory
+from hydra_slayer.factory import (
+    call_meta_factory,
+    default_meta_factory,
+    metafactory_factory,
+    partial_meta_factory,
+)
 from hydra_slayer.functional import get_factory, get_from_params, get_instance
 from hydra_slayer.registry import Registry

--- a/hydra_slayer/factory.py
+++ b/hydra_slayer/factory.py
@@ -3,47 +3,22 @@ import copy
 import functools
 import inspect
 
-__all__ = ["call_meta_factory", "partial_meta_factory", "default_meta_factory"]
+__all__ = [
+    "metafactory_factory",
+    "call_meta_factory",
+    "partial_meta_factory",
+    "default_meta_factory",
+]
 
 Factory = Union[Type, Callable[..., Any]]
-MetaFactory = Callable[[Factory, Tuple, Mapping], Any]
 
-DEFAULT_CALL_MODE_KEY = "_mode_"
-
-
-def call_meta_factory(factory: Factory, args: Tuple, kwargs: Mapping):
-    """Creates a new instance from ``factory``.
-
-    Args:
-        factory: factory to create instance from
-        args: \*args to pass to the factory
-        kwargs: \*\*kwargs to pass to the factory
-
-    Returns:
-        Instance.
-
-    """
-    return factory(*args, **kwargs)
+# DEFAULT_ATTR_KEY = "_attr_"
+DEFAULT_FROM_PARAMS_KEY = "get_from_params"
+DEFAULT_META_FACTORY_KEY = "_meta_factory_"
+DEFAULT_CALL_MODE_KEY = "_mode_"  # TODO: (@scitator) rename (maybe to `_fit_`?)
 
 
-def partial_meta_factory(factory: Factory, args: Tuple, kwargs: Mapping):
-    """
-    Returns a new partial object which when called will behave like func called
-    with the positional arguments ``args`` and keyword arguments ``kwargs``.
-
-    Args:
-        factory: factory to create instance from
-        args: \*args to merge into the factory
-        kwargs: \*\*kwargs to merge into the factory
-
-    Returns:
-        Partial object.
-
-    """
-    return functools.partial(factory, *args, **kwargs)
-
-
-def default_meta_factory(factory: Factory, args: Tuple, kwargs: Mapping):
+def metafactory_factory(factory: Factory, args: Tuple, kwargs: Mapping):
     """Returns a new instance or a new partial object.
 
       * _mode_='auto'
@@ -94,10 +69,92 @@ def default_meta_factory(factory: Factory, args: Tuple, kwargs: Mapping):
     """
     # make a copy of kwargs since we don't want to modify them directly
     kwargs = copy.copy(kwargs)
-    mode = kwargs.pop(DEFAULT_CALL_MODE_KEY, "auto")
-    if mode not in {"auto", "call", "partial"}:
-        raise ValueError(f"`{mode}` is not a valid call mode")
+    meta_factory = kwargs.pop(DEFAULT_META_FACTORY_KEY, None)
+    meta_factory_name = kwargs.pop(DEFAULT_CALL_MODE_KEY, "auto")
 
-    if mode == "auto" and inspect.isfunction(factory) or mode == "partial":
-        return partial_meta_factory(factory, args, kwargs)
-    return call_meta_factory(factory, args, kwargs)
+    # TODO: (replace with `_attr_` and) remove {
+    if hasattr(factory, DEFAULT_FROM_PARAMS_KEY):
+        return getattr(factory, DEFAULT_FROM_PARAMS_KEY)(*args, **kwargs)
+    # TODO: } remove
+
+    if meta_factory is None:
+        meta_factories = {
+            "auto": default_meta_factory,
+            "call": call_meta_factory,
+            "partial": partial_meta_factory,
+        }
+        if meta_factory_name not in meta_factories.keys():
+            raise ValueError(f"'{meta_factory_name}' is not a valid call mode")
+        meta_factory = meta_factories[meta_factory_name]
+
+    return meta_factory(factory, args=args, kwargs=kwargs)
+
+
+def call_meta_factory(factory: Factory, args: Tuple, kwargs: Mapping):
+    """Creates a new instance from ``factory``.
+
+    Args:
+        factory: factory to create instance from
+        args: \*args to pass to the factory
+        kwargs: \*\*kwargs to pass to the factory
+
+    Returns:
+        Instance.
+
+    """
+    return factory(*args, **kwargs)
+
+
+def partial_meta_factory(factory: Factory, args: Tuple, kwargs: Mapping):
+    """
+    Returns a new partial object which when called will behave like func called
+    with the positional arguments ``args`` and keyword arguments ``kwargs``.
+
+    Args:
+        factory: factory to create instance from
+        args: \*args to merge into the factory
+        kwargs: \*\*kwargs to merge into the factory
+
+    Returns:
+        Partial object.
+
+    """
+    return functools.partial(factory, *args, **kwargs)
+
+
+def default_meta_factory(factory: Factory, args: Tuple, kwargs: Mapping):
+    """Returns a new instance or a new partial object.
+
+    Creates a new instance from ``factory`` if ``factory`` is class
+    (like :py:func:`call_meta_factory`), else returns a new partial object
+    (like :py:func:`partial_meta_factory`).
+
+    Args:
+        factory: factory to create instance from
+        args: \*args to pass to the factory
+        kwargs: \*\*kwargs to pass to the factory
+
+    Returns:
+        Instance.
+
+    Raises:
+        ValueError: if factory object is not callable.
+
+    Examples:
+        >>> default_meta_factory(int, (42,))
+        42
+
+        >>> # please note that additional () are used
+        >>> default_meta_factory(lambda x: x, (42,))()
+        42
+
+        >>> default_meta_factory(int, ('42',), {"base": 16})
+        66
+    """
+    if inspect.isclass(factory):
+        obj = call_meta_factory(factory, args, kwargs)
+    elif inspect.ismethod(factory) or inspect.isfunction(factory):
+        obj = partial_meta_factory(factory, args, kwargs)
+    else:
+        raise ValueError(f"factory '{factory}' is not callable")
+    return obj

--- a/hydra_slayer/registry.py
+++ b/hydra_slayer/registry.py
@@ -4,7 +4,7 @@ import inspect
 import warnings
 
 from hydra_slayer import functional as F
-from hydra_slayer.factory import default_meta_factory, Factory, MetaFactory
+from hydra_slayer.factory import Factory
 
 __all__ = ["Registry"]
 
@@ -16,13 +16,10 @@ class Registry(abc.MutableMapping):
     Universal class allowing to add and access various factories by name.
 
     Args:
-        meta_factory: default object that calls factory.
-            Default: :py:func:`.factory.default_meta_factory`
         name_key: key to use to extract names of the factories from
     """
 
-    def __init__(self, meta_factory: MetaFactory = None, name_key: str = "_target_"):
-        self.meta_factory = meta_factory if meta_factory is not None else default_meta_factory
+    def __init__(self, name_key: str = "_target_"):
         self._factories: Dict[str, Factory] = {}
         self._late_add_callbacks: List[LateAddCallback] = []
         self.name_key = name_key
@@ -107,7 +104,10 @@ class Registry(abc.MutableMapping):
         self._late_add_callbacks.append(cb)
 
     def add_from_module(
-        self, module, prefix: Union[str, List[str]] = None, ignore_all: bool = False
+        self,
+        module,
+        prefix: Union[str, List[str]] = None,
+        ignore_all: bool = False,
     ) -> None:
         """
         Adds all factories present in module.
@@ -174,25 +174,19 @@ class Registry(abc.MutableMapping):
             return self.get(obj)
         return obj
 
-    def get_instance(self, *args, meta_factory: Optional[MetaFactory] = None, **kwargs):
+    def get_instance(self, *args, **kwargs):
         """
         Creates instance by calling specified factory with ``instantiate_fn``.
 
         Args:
             *args: \*args to pass to the factory
-            meta_factory: function that calls factory the right way.
-                Default: :py:func:`.factory.default_meta_factory`
             **kwargs: \*\*kwargs to pass to the factory
 
         Returns:
             created instance
         """
         instance = F._get_instance(
-            factory_key=self.name_key,
-            get_factory_func=self.get,
-            meta_factory=meta_factory or self.meta_factory,
-            args=args,
-            kwargs=kwargs,
+            factory_key=self.name_key, get_factory_func=self.get, args=args, kwargs=kwargs
         )
         return instance
 

--- a/tests/foobar.py
+++ b/tests/foobar.py
@@ -24,3 +24,9 @@ def quux(a=1, b=2, **kwargs):
 
 def quuz(**params):
     return {"a": params["a"], "b": params["b"]}
+
+
+class grault:
+    @staticmethod
+    def garply(a, b):
+        return {"a": a, "b": b}


### PR DESCRIPTION
Logic behind meta factories e.g. `_mode_` key-value, moved from
`default_meta_factory` and `_meta_factory_call` into `metafactory_factory`