### PR TITLE
feat: support of `var.attr` added

### DIFF
--- a/hydra_slayer/factory.py
+++ b/hydra_slayer/factory.py
@@ -12,10 +12,9 @@ __all__ = [
 
 Factory = Union[Type, Callable[..., Any]]
 
-# DEFAULT_ATTR_KEY = "_attr_"
 DEFAULT_FROM_PARAMS_KEY = "get_from_params"
 DEFAULT_META_FACTORY_KEY = "_meta_factory_"
-DEFAULT_CALL_MODE_KEY = "_mode_"  # TODO: (@scitator) rename (maybe to `_fit_`?)
+DEFAULT_CALL_MODE_KEY = "_mode_"  # TODO: discuss with @scitator and rename
 
 
 def metafactory_factory(factory: Factory, args: Tuple, kwargs: Mapping):
@@ -67,10 +66,9 @@ def metafactory_factory(factory: Factory, args: Tuple, kwargs: Mapping):
     meta_factory = kwargs.pop(DEFAULT_META_FACTORY_KEY, None)
     meta_factory_name = kwargs.pop(DEFAULT_CALL_MODE_KEY, "auto")
 
-    # TODO: (replace with `_attr_` and) remove {
+    # legacy, for the compatibility with the Catalyst library
     if hasattr(factory, DEFAULT_FROM_PARAMS_KEY):
         return getattr(factory, DEFAULT_FROM_PARAMS_KEY)(*args, **kwargs)
-    # TODO: } remove
 
     if meta_factory is None:
         meta_factories = {

--- a/hydra_slayer/functional.py
+++ b/hydra_slayer/functional.py
@@ -165,8 +165,12 @@ def _get_from_params(
 
         obj = vars_dict[alias]
         if attribute_name is not None:
-            attr = getattr(obj, attribute_name)
-            obj = attr(**kwargs) if inspect.ismethod(attr) or inspect.isfunction(attr) else attr
+            obj_or_callable = getattr(obj, attribute_name)
+            if callable(obj_or_callable):
+                args, kwargs = _extract_positional_keyword_vars(obj_or_callable, kwargs=kwargs)
+                obj = obj_or_callable(*args, **kwargs)
+            else:
+                obj = obj_or_callable
     elif factory_key in kwargs:
         obj = _get_instance(
             factory_key=factory_key,

--- a/hydra_slayer/registry.py
+++ b/hydra_slayer/registry.py
@@ -21,12 +21,20 @@ class Registry(abc.MutableMapping):
             and then refer to that item and reuse it multiple times.
     """
 
-    def __init__(self, name_key: str = "_target_", var_key: str = "_var_"):
+    def __init__(
+        self,
+        name_key: str = "_target_",
+        var_key: str = "_var_",
+        attrs_key: str = "_attr_",
+        attrs_delimiter: str = ".",
+    ):
         self._factories: Dict[str, Factory] = {}
         self._late_add_callbacks: List[LateAddCallback] = []
         self.name_key = name_key
         self.var_key = var_key
         self._vars_dict = {}
+        self.attrs_key = attrs_key
+        self.attrs_delimiter = attrs_delimiter
 
     @staticmethod
     def _get_factory_name(f, provided_name: str = None) -> str:
@@ -216,6 +224,8 @@ class Registry(abc.MutableMapping):
             shared_params=shared_params or {},
             var_key=self.var_key,
             vars_dict=self._vars_dict,
+            attrs_key=self.attrs_key,
+            attrs_delimiter=self.attrs_delimiter,
         )
         return instance
 

--- a/hydra_slayer/registry.py
+++ b/hydra_slayer/registry.py
@@ -17,24 +17,26 @@ class Registry(abc.MutableMapping):
 
     Args:
         name_key: key to use to extract names of the factories from
-        var_key: key to use to for aliases. Aliases let you identify an item
-            and then refer to that item and reuse it multiple times.
+        var_key: key to use to for aliases, aliases let you identify an item
+            and then refer to that item and reuse it multiple times
+        attrs_delimiter: delimiter to use for separation of alias and
+            attribute of an instance to get
     """
 
     def __init__(
         self,
-        name_key: str = "_target_",
-        var_key: str = "_var_",
-        attrs_key: str = "_attr_",
-        attrs_delimiter: str = ".",
+        name_key: str = F.DEFAULT_FACTORY_KEY,
+        var_key: str = F.DEFAULT_VAR_KEY,
+        attrs_delimiter: str = F.DEFAULT_ATTRS_DELIMITER,
     ):
-        self._factories: Dict[str, Factory] = {}
         self._late_add_callbacks: List[LateAddCallback] = []
+
         self.name_key = name_key
+        self._factories: Dict[str, Factory] = {}
+
         self.var_key = var_key
-        self._vars_dict = {}
-        self.attrs_key = attrs_key
         self.attrs_delimiter = attrs_delimiter
+        self._vars_dict = {}
 
     @staticmethod
     def _get_factory_name(f, provided_name: str = None) -> str:
@@ -223,9 +225,8 @@ class Registry(abc.MutableMapping):
             params=kwargs,
             shared_params=shared_params or {},
             var_key=self.var_key,
-            vars_dict=self._vars_dict,
-            attrs_key=self.attrs_key,
             attrs_delimiter=self.attrs_delimiter,
+            vars_dict=self._vars_dict,
         )
         return instance
 

--- a/tests/foobar.py
+++ b/tests/foobar.py
@@ -27,6 +27,16 @@ def quuz(**params):
 
 
 class grault:
+    def __init__(self, a=1, b=2):
+        self.a = a
+        self.b = b
+
     @staticmethod
     def garply(a, b):
         return {"a": a, "b": b}
+
+    def waldo(self):
+        return {"a": self.a, "b": self.b}
+
+    def fred(self):
+        return self

--- a/tests/foobar.py
+++ b/tests/foobar.py
@@ -37,6 +37,3 @@ class grault:
 
     def waldo(self):
         return {"a": self.a, "b": self.b}
-
-    def fred(self):
-        return self

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -320,3 +320,37 @@ def test_get_from_params_var_keyword():
         shared_params={"_mode_": "call"},
     )
     assert res == {"a": (1, 2), "b": {"a": (1, 2), "b": 3}}
+
+
+def test_get_from_params_attrs():
+    res = F.get_from_params(
+        **{"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_attr_": "waldo"},
+        shared_params={"_mode_": "call"},
+    )
+    assert res == {"a": 3, "b": 4}
+
+    res = F.get_from_params(
+        **{"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_attr_": "fred.fred.waldo"},
+        shared_params={"_mode_": "call"},
+    )
+    assert res == {"a": 3, "b": 4}
+
+
+def test_get_from_params_var_attrs():
+    res = F.get_from_params(
+        **{
+            "a": {"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_var_": "x"},
+            "b": {"_var_": "x", "_attr_": "waldo"},
+        },
+        shared_params={"_mode_": "call"},
+    )
+    assert res["b"] == {"a": 3, "b": 4}
+
+    res = F.get_from_params(
+        **{
+            "a": {"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_var_": "x"},
+            "b": {"_var_": "x", "_attr_": "fred.fred.waldo"},
+        },
+        shared_params={"_mode_": "call"},
+    )
+    assert res["b"] == {"a": 3, "b": 4}

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -95,18 +95,8 @@ def test_get_from_recursive_params():
     res = F.get_from_params(
         **{
             "_target_": "tests.foobar.foo",
-            "a": {
-                "_target_": "tests.foobar.foo",
-                "a": 1,
-                "b": 2,
-                "_mode_": "call",
-            },
-            "b": {
-                "_target_": "tests.foobar.foo",
-                "a": 3,
-                "b": 4,
-                "_mode_": "call",
-            },
+            "a": {"_target_": "tests.foobar.foo", "_mode_": "call", "a": 1, "b": 2},
+            "b": {"_target_": "tests.foobar.foo", "_mode_": "call", "a": 3, "b": 4},
         },
     )()
     assert res["a"] == {"a": 1, "b": 2} and res["b"] == {"a": 3, "b": 4}
@@ -127,7 +117,7 @@ def test_get_from_params_shared_params():
             "_target_": "tests.foobar.foo",
             "a": {"_target_": "tests.foobar.foo", "a": 1, "b": 2},
         },
-        shared_params={"b": 3, "_mode_": "call"},
+        shared_params={"_mode_": "call", "b": 3},
     )
     assert res == {"a": {"a": 1, "b": 2}, "b": 3}
 
@@ -296,7 +286,7 @@ def test_get_from_params_kwargs_support():
 def test_get_from_params_var_keyword():
     res = F.get_from_params(
         **{
-            "a": {"_target_": "tests.foobar.foo", "a": 1, "b": 2, "_var_": "x"},
+            "a": {"_var_": "x", "_target_": "tests.foobar.foo", "a": 1, "b": 2},
             "b": {"_target_": "tests.foobar.foo", "a": {"_var_": "x"}, "b": 3},
         },
         shared_params={"_mode_": "call"},
@@ -305,7 +295,7 @@ def test_get_from_params_var_keyword():
 
     res = F.get_from_params(
         **{
-            "a": {"a": 1, "_var_": "x"},
+            "a": {"_var_": "x", "a": 1},
             "b": {"_target_": "tests.foobar.foo", "a": {"_var_": "x"}, "b": 2},
         },
         shared_params={"_mode_": "call"},
@@ -314,7 +304,7 @@ def test_get_from_params_var_keyword():
 
     res = F.get_from_params(
         **{
-            "a": {"_target_": "tests.foobar.qux", "a": 1, "b": 2, "_var_": "x"},
+            "a": {"_var_": "x", "_target_": "tests.foobar.qux", "a": 1, "b": 2},
             "b": {"_target_": "tests.foobar.foo", "a": {"_var_": "x"}, "b": 3},
         },
         shared_params={"_mode_": "call"},
@@ -322,35 +312,49 @@ def test_get_from_params_var_keyword():
     assert res == {"a": (1, 2), "b": {"a": (1, 2), "b": 3}}
 
 
-def test_get_from_params_attrs():
-    res = F.get_from_params(
-        **{"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_attr_": "waldo"},
-        shared_params={"_mode_": "call"},
-    )
-    assert res == {"a": 3, "b": 4}
-
-    res = F.get_from_params(
-        **{"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_attr_": "fred.fred.waldo"},
-        shared_params={"_mode_": "call"},
-    )
-    assert res == {"a": 3, "b": 4}
-
-
-def test_get_from_params_var_attrs():
+def test_get_from_params_var_attr():
     res = F.get_from_params(
         **{
-            "a": {"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_var_": "x"},
-            "b": {"_var_": "x", "_attr_": "waldo"},
+            "a": {
+                "_var_": "x",
+                "_target_": "tests.foobar.grault",
+                "_mode_": "call",
+                "a": 3,
+                "b": 4,
+            },
+            "b": {"_var_": "x.b"},
         },
-        shared_params={"_mode_": "call"},
+    )
+    assert res["b"] == 4
+
+
+def test_get_from_params_var_method_without_params():
+    res = F.get_from_params(
+        **{
+            "a": {
+                "_var_": "x",
+                "_target_": "tests.foobar.grault",
+                "_mode_": "call",
+                "a": 3,
+                "b": 4,
+            },
+            "b": {"_var_": "x.waldo"},
+        },
     )
     assert res["b"] == {"a": 3, "b": 4}
 
+
+def test_get_from_params_var_method_with_params():
     res = F.get_from_params(
         **{
-            "a": {"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_var_": "x"},
-            "b": {"_var_": "x", "_attr_": "fred.fred.waldo"},
+            "a": {
+                "_var_": "x",
+                "_target_": "tests.foobar.grault",
+                "_mode_": "call",
+                "a": 3,
+                "b": 4,
+            },
+            "b": {"_var_": "x.garply", "a": 1, "b": 2},
         },
-        shared_params={"_mode_": "call"},
     )
-    assert res["b"] == {"a": 3, "b": 4}
+    assert res["b"] == {"a": 1, "b": 2}

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -357,3 +357,57 @@ def test_get_from_params_vars_dict():
         shared_params={"_mode_": "call"},
     )
     assert res == {"a": {"a": 1, "b": 2}, "b": 3}
+
+
+def test_get_from_params_attrs():
+    r = Registry()
+
+    r.add(foo)
+
+    res = r.get_from_params(
+        **{"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_attr_": "waldo"},
+        shared_params={"_mode_": "call"},
+    )
+    assert res == {"a": 3, "b": 4}
+
+    res = r.get_from_params(
+        **{"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_attr_": "fred.fred.waldo"},
+        shared_params={"_mode_": "call"},
+    )
+    assert res == {"a": 3, "b": 4}
+
+
+def test_get_from_params_attrs_keyword():
+    r = Registry(attrs_key="_attributes_", attrs_delimiter="/")
+
+    r.add(foo)
+
+    res = r.get_from_params(
+        **{"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_attributes_": "fred/fred/waldo"},
+        shared_params={"_mode_": "call"},
+    )
+    assert res == {"a": 3, "b": 4}
+
+
+def test_get_from_params_var_attrs():
+    r = Registry()
+
+    r.add(foo)
+
+    res = r.get_from_params(
+        **{
+            "a": {"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_var_": "x"},
+            "b": {"_var_": "x", "_attr_": "waldo"},
+        },
+        shared_params={"_mode_": "call"},
+    )
+    assert res["b"] == {"a": 3, "b": 4}
+
+    res = r.get_from_params(
+        **{
+            "a": {"_target_": "tests.foobar.grault", "a": 3, "b": 4, "_var_": "x"},
+            "b": {"_var_": "x", "_attr_": "fred.fred.waldo"},
+        },
+        shared_params={"_mode_": "call"},
+    )
+    assert res["b"] == {"a": 3, "b": 4}


### PR DESCRIPTION
support of `var.attr` added, e.g.:
```yaml
model:
  _var_: model
  _target_: torchvision.models.resnet.resnet34
  _mode_: call
  num_classes: 2

optimizer:
  _target_: torch.optim.SGD
  params:
    _var_: model.parameters
  lr: 0.001
  momentum: 0.0001
  weight_decay: 0.0001
```